### PR TITLE
fixed code scrolling on iOS

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -167,10 +167,9 @@ pre {
   font-size: .8rem;
   line-height: 1.4;
   white-space: pre;
-  white-space: pre-wrap;
-  word-break: break-all;
-  word-wrap: break-word;
   background-color: #f9f9f9;
+  overflow: auto !important;
+  width: 100% !important;
 }
 pre code {
   padding: 0;


### PR DESCRIPTION
This makes the code scrollable horizontally instead of doing word breaks that make the code completely unreadable on iOS Safari (and probably other mobile devices).

Before:

![before](https://i.imgur.com/tFrrTa2.png)

After (different website, but the theme is the same):

![after](https://i.imgur.com/M7a0TB1.png)